### PR TITLE
fix(websocket): 临时禁用TLS验证并优化WebSocket配置

### DIFF
--- a/echome-be/client/aliyun/asr.go
+++ b/echome-be/client/aliyun/asr.go
@@ -2,6 +2,7 @@ package aliyun
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -80,6 +81,9 @@ func connectToModelStudioASR(apiKey string, config domain.ASRConfig) (*websocket
 		HandshakeTimeout: 30 * time.Second,
 		ReadBufferSize:   4096,
 		WriteBufferSize:  4096,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // 临时禁用验证
+		},
 	}
 
 	headers := http.Header{}

--- a/echome-be/client/aliyun/tts.go
+++ b/echome-be/client/aliyun/tts.go
@@ -2,6 +2,7 @@ package aliyun
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -66,6 +67,11 @@ func connectToAliyunTTS(apiKey, endpoint, model string) (*websocket.Conn, error)
 
 	dialer := websocket.Dialer{
 		HandshakeTimeout: 30 * time.Second,
+		ReadBufferSize:   4096,
+		WriteBufferSize:  4096,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // 临时禁用验证
+		},
 	}
 
 	headers := http.Header{}


### PR DESCRIPTION
为ASR和TTS服务临时禁用TLS证书验证以解决连接问题
优化WebSocket升级器的缓冲区大小和超时设置
统一使用response包返回错误响应
添加WebSocket连接的上下文感知关闭处理