### PR TITLE
fix: 添加TLS配置以跳过证书验证

### DIFF
--- a/echome-be/client/search.go
+++ b/echome-be/client/search.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -57,7 +58,13 @@ func PerformSearch(query string, apiKey string) (string, error) {
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // 关闭TLS验证
+			},
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
在http.Client中添加TLS配置，设置InsecureSkipVerify为true以跳过TLS证书验证。