### PR TITLE
fix(Dockerfile): 修正构建目标路径从cmd/api到cmd/main

### DIFF
--- a/echome-be/Dockerfile
+++ b/echome-be/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     go build -v -a -installsuffix cgo \
     -ldflags="-s -w" \
-    -o ${APP_NAME} ./cmd/api
+    -o ${APP_NAME} ./cmd/main
 
 # 运行时阶段
 FROM scratch


### PR DESCRIPTION
构建命令中的目标路径错误导致无法正确编译，将其从cmd/api修正为cmd/main